### PR TITLE
Fix/remove ordinal position seeding

### DIFF
--- a/Core/Controllers/StatusBarController.swift
+++ b/Core/Controllers/StatusBarController.swift
@@ -238,74 +238,6 @@ final class StatusBarController: StatusBarControllerProtocol {
 
     // MARK: - Position Pre-Seeding
 
-    /// Seed ordinal positions BEFORE creating status items.
-    /// Only seed when positions are missing/invalid. Re-seeding on every launch
-    /// destroys user-arranged visible/hidden layouts.
-    private static func seedPositionsIfNeeded() {
-        let mainValues = preferredPositionValues(forAutosaveName: mainAutosaveName)
-        let separatorValues = preferredPositionValues(forAutosaveName: separatorAutosaveName)
-
-        let seedMain = shouldSeedPreferredPosition(appValue: mainValues.appValue, byHostValue: mainValues.byHostValue)
-        let seedSeparator = shouldSeedPreferredPosition(appValue: separatorValues.appValue, byHostValue: separatorValues.byHostValue)
-
-        if seedMain {
-            logger.info("Seeding main position (main=0)")
-            setPreferredPosition(0, forAutosaveName: mainAutosaveName)
-        }
-        if seedSeparator {
-            logger.info("Seeding separator position (separator=1)")
-            setPreferredPosition(1, forAutosaveName: separatorAutosaveName)
-        }
-
-        if !seedMain, !seedSeparator {
-            logger.debug("Preserving existing main/separator positions")
-        }
-    }
-
-    private static func forceMainAndSeparatorAnchorSeed() {
-        logger.info("Onboarding startup: forcing main/separator anchor seeds near Control Center")
-        setPreferredPosition(0, forAutosaveName: mainAutosaveName)
-        setPreferredPosition(1, forAutosaveName: separatorAutosaveName)
-    }
-
-    private static func shouldForceAnchorNearControlCenterOnLaunch() -> Bool {
-        if let forced = ProcessInfo.processInfo.environment["SANEBAR_FORCE_ANCHOR_ON_LAUNCH"] {
-            return forced == "1"
-        }
-
-        // Unit tests intentionally exercise migration/seed behavior with crafted
-        // defaults and should not be affected by onboarding-first-run policy.
-        if NSClassFromString("XCTestCase") != nil ||
-            ProcessInfo.processInfo.environment["XCTestConfigurationFilePath"] != nil {
-            return false
-        }
-
-        guard let base = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first else {
-            return true
-        }
-        let settingsURL = base.appendingPathComponent("SaneBar", isDirectory: true)
-            .appendingPathComponent("settings.json")
-
-        guard let data = try? Data(contentsOf: settingsURL),
-              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
-        else {
-            // No settings file yet => true first launch.
-            return true
-        }
-
-        // Legacy upgrade path:
-        // Older installs may have a settings file without onboarding keys.
-        // Treat those users as completed so we do NOT re-force anchor seeds.
-        if json["hasCompletedOnboarding"] == nil {
-            logger.info("Legacy settings detected (missing hasCompletedOnboarding) — skipping forced anchor seed")
-            return false
-        }
-
-        // Keep forcing anchor until onboarding is fully complete.
-        let hasCompletedOnboarding = (json["hasCompletedOnboarding"] as? Bool) ?? false
-        return !hasCompletedOnboarding
-    }
-
     static func seedAlwaysHiddenSeparatorPositionIfNeeded() {
         // AH separator must be FAR to the left of all menu bar items.
         // UserDefaults positions are pixel offsets from the right screen edge.
@@ -548,16 +480,6 @@ final class StatusBarController: StatusBarControllerProtocol {
 
     private static func byHostPreferredPositionKey(for autosaveName: String) -> String {
         "NSStatusItem Preferred Position \(byHostAutosaveName(for: autosaveName))"
-    }
-
-    nonisolated static func shouldSeedPreferredPosition(appValue: Any?, byHostValue: Any?) -> Bool {
-        if let appNumber = numericPositionValue(appValue), appNumber.isFinite {
-            return false
-        }
-        if let byHostNumber = numericPositionValue(byHostValue), byHostNumber.isFinite {
-            return false
-        }
-        return true
     }
 
     private nonisolated static func numericPositionValue(_ value: Any?) -> Double? {

--- a/Tests/StatusBarControllerTests.swift
+++ b/Tests/StatusBarControllerTests.swift
@@ -128,146 +128,6 @@ struct StatusBarControllerTests {
         #expect(StatusBarController.mainAutosaveName == "SaneBar_Main_v11")
     }
 
-    @Test("Position seed runs when both app and ByHost values are missing")
-    func shouldSeedWhenAllValuesMissing() {
-        let shouldSeed = StatusBarController.shouldSeedPreferredPosition(
-            appValue: nil,
-            byHostValue: nil
-        )
-        #expect(shouldSeed == true)
-    }
-
-    @Test("Position seed skips when app value already exists")
-    func shouldNotSeedWhenAppValueExists() {
-        let shouldSeed = StatusBarController.shouldSeedPreferredPosition(
-            appValue: 42,
-            byHostValue: nil
-        )
-        #expect(shouldSeed == false)
-    }
-
-    @Test("Position seed skips when ByHost value already exists")
-    func shouldNotSeedWhenByHostValueExists() {
-        let shouldSeed = StatusBarController.shouldSeedPreferredPosition(
-            appValue: nil,
-            byHostValue: NSNumber(value: 17)
-        )
-        #expect(shouldSeed == false)
-    }
-
-    @Test("Position seed skips when app value is numeric string")
-    func shouldNotSeedWhenAppValueStringExists() {
-        let shouldSeed = StatusBarController.shouldSeedPreferredPosition(
-            appValue: "42",
-            byHostValue: nil
-        )
-        #expect(shouldSeed == false)
-    }
-
-    @Test("Position seed skips when ByHost value is numeric string")
-    func shouldNotSeedWhenByHostValueStringExists() {
-        let shouldSeed = StatusBarController.shouldSeedPreferredPosition(
-            appValue: nil,
-            byHostValue: "17"
-        )
-        #expect(shouldSeed == false)
-    }
-
-    @Test("Position seed ignores invalid non-numeric values")
-    func shouldSeedWhenValuesAreInvalid() {
-        let shouldSeed = StatusBarController.shouldSeedPreferredPosition(
-            appValue: "bad",
-            byHostValue: Date()
-        )
-        #expect(shouldSeed == true)
-    }
-
-    @Test("Init forces anchor seeding when launch override is enabled")
-    @MainActor
-    func initForcesAnchorWhenOverrideEnabled() {
-        let defaults = UserDefaults.standard
-        let mainKey = "NSStatusItem Preferred Position \(StatusBarController.mainAutosaveName)"
-        let separatorKey = "NSStatusItem Preferred Position \(StatusBarController.separatorAutosaveName)"
-        let screenWidthKey = "SaneBar_CalibratedScreenWidth"
-        let migrationKey = "SaneBar_PositionRecovery_Migration_v1"
-        let keys = [mainKey, separatorKey, screenWidthKey, migrationKey]
-        let originalValues: [(String, Any?)] = keys.map { ($0, defaults.object(forKey: $0)) }
-        let variable = "SANEBAR_FORCE_ANCHOR_ON_LAUNCH"
-        let originalEnv = getenv(variable).map { String(cString: $0) }
-        defer {
-            for (key, value) in originalValues {
-                if let value {
-                    defaults.set(value, forKey: key)
-                } else {
-                    defaults.removeObject(forKey: key)
-                }
-            }
-            if let originalEnv {
-                setenv(variable, originalEnv, 1)
-            } else {
-                unsetenv(variable)
-            }
-        }
-
-        defaults.set(true, forKey: migrationKey)
-        if let width = NSScreen.main?.frame.width {
-            defaults.set(width, forKey: screenWidthKey)
-        }
-        defaults.set(420.0, forKey: mainKey)
-        defaults.set(360.0, forKey: separatorKey)
-
-        setenv(variable, "1", 1)
-        _ = StatusBarController()
-
-        let mainValue = (defaults.object(forKey: mainKey) as? NSNumber)?.doubleValue
-        let separatorValue = (defaults.object(forKey: separatorKey) as? NSNumber)?.doubleValue
-        #expect(mainValue == 0.0, "Override should force main anchor seed")
-        #expect(separatorValue == 1.0, "Override should force separator anchor seed")
-    }
-
-    @Test("Init preserves existing positions when launch override is disabled")
-    @MainActor
-    func initPreservesPositionsWhenOverrideDisabled() {
-        let defaults = UserDefaults.standard
-        let mainKey = "NSStatusItem Preferred Position \(StatusBarController.mainAutosaveName)"
-        let separatorKey = "NSStatusItem Preferred Position \(StatusBarController.separatorAutosaveName)"
-        let screenWidthKey = "SaneBar_CalibratedScreenWidth"
-        let migrationKey = "SaneBar_PositionRecovery_Migration_v1"
-        let keys = [mainKey, separatorKey, screenWidthKey, migrationKey]
-        let originalValues: [(String, Any?)] = keys.map { ($0, defaults.object(forKey: $0)) }
-        let variable = "SANEBAR_FORCE_ANCHOR_ON_LAUNCH"
-        let originalEnv = getenv(variable).map { String(cString: $0) }
-        defer {
-            for (key, value) in originalValues {
-                if let value {
-                    defaults.set(value, forKey: key)
-                } else {
-                    defaults.removeObject(forKey: key)
-                }
-            }
-            if let originalEnv {
-                setenv(variable, originalEnv, 1)
-            } else {
-                unsetenv(variable)
-            }
-        }
-
-        defaults.set(true, forKey: migrationKey)
-        if let width = NSScreen.main?.frame.width {
-            defaults.set(width, forKey: screenWidthKey)
-        }
-        defaults.set(420.0, forKey: mainKey)
-        defaults.set(360.0, forKey: separatorKey)
-
-        setenv(variable, "0", 1)
-        _ = StatusBarController()
-
-        let mainValue = (defaults.object(forKey: mainKey) as? NSNumber)?.doubleValue
-        let separatorValue = (defaults.object(forKey: separatorKey) as? NSNumber)?.doubleValue
-        #expect(mainValue == 420.0, "Disabled override should preserve existing main position")
-        #expect(separatorValue == 360.0, "Disabled override should preserve existing separator position")
-    }
-
     @Test("Init clears persisted status-item visibility overrides")
     @MainActor
     func initClearsPersistedVisibilityOverrides() {
@@ -459,10 +319,10 @@ struct StatusBarControllerTests {
 
         _ = StatusBarController()
 
-        let mainValue = (defaults.object(forKey: mainKey) as? NSNumber)?.doubleValue
-        let separatorValue = (defaults.object(forKey: separatorKey) as? NSNumber)?.doubleValue
-        #expect(mainValue == 0.0, "Corrupted legacy AH position should trigger main reset to ordinal seed")
-        #expect(separatorValue == 1.0, "Corrupted legacy AH position should trigger separator reset to ordinal seed")
+        let mainValue = defaults.object(forKey: mainKey)
+        let separatorValue = defaults.object(forKey: separatorKey)
+        #expect(mainValue == nil, "Corrupted legacy AH position should clear main position")
+        #expect(separatorValue == nil, "Corrupted legacy AH position should clear separator position")
         #expect(defaults.bool(forKey: "SaneBar_PositionRecovery_Migration_v1"),
                 "Stable migration key should be set after recovery")
     }
@@ -476,8 +336,8 @@ struct StatusBarControllerTests {
             let separator: Double?
             let alwaysHidden: Double?
             let legacyAlwaysHidden: Double?
-            let expectedMain: Double
-            let expectedSeparator: Double
+            let expectedMain: Double?
+            let expectedSeparator: Double?
         }
 
         let defaults = UserDefaults.standard
@@ -521,8 +381,8 @@ struct StatusBarControllerTests {
                 separator: 360.0,
                 alwaysHidden: 10000.0,
                 legacyAlwaysHidden: 50.0,
-                expectedMain: 0.0,
-                expectedSeparator: 1.0
+                expectedMain: nil,
+                expectedSeparator: nil
             ),
             Scenario(
                 name: "v2.1.6 invalid separator position",
@@ -530,8 +390,8 @@ struct StatusBarControllerTests {
                 separator: -24.0,
                 alwaysHidden: 10000.0,
                 legacyAlwaysHidden: nil,
-                expectedMain: 0.0,
-                expectedSeparator: 1.0
+                expectedMain: nil,
+                expectedSeparator: nil
             )
         ]
 
@@ -571,8 +431,8 @@ struct StatusBarControllerTests {
 
             let mainValue = (defaults.object(forKey: mainKey) as? NSNumber)?.doubleValue
             let separatorValue = (defaults.object(forKey: separatorKey) as? NSNumber)?.doubleValue
-            #expect(mainValue == scenario.expectedMain, "\(scenario.name): main position mismatch")
-            #expect(separatorValue == scenario.expectedSeparator, "\(scenario.name): separator position mismatch")
+            #expect(mainValue == scenario.expectedMain, "\(scenario.name): main position mismatch (got \(String(describing: mainValue)))")
+            #expect(separatorValue == scenario.expectedSeparator, "\(scenario.name): separator position mismatch (got \(String(describing: separatorValue)))")
             #expect(defaults.bool(forKey: "SaneBar_PositionRecovery_Migration_v1"),
                     "\(scenario.name): migration key should be set")
         }
@@ -687,17 +547,17 @@ struct StatusBarControllerTests {
             defaults.set(currentWidth, forKey: "SaneBar_CalibratedScreenWidth")
         }
 
-        // First launch from corrupted legacy state should recover to 0/1.
+        // First launch from corrupted legacy state should clear positions.
         defaults.set(420.0, forKey: mainKey)
         defaults.set(360.0, forKey: separatorKey)
         defaults.set(10000.0, forKey: alwaysHiddenKey)
         defaults.set(50.0, forKey: legacyAlwaysHiddenKey)
         _ = StatusBarController()
 
-        let recoveredMain = (defaults.object(forKey: mainKey) as? NSNumber)?.doubleValue
-        let recoveredSeparator = (defaults.object(forKey: separatorKey) as? NSNumber)?.doubleValue
-        #expect(recoveredMain == 0.0)
-        #expect(recoveredSeparator == 1.0)
+        let recoveredMain = defaults.object(forKey: mainKey)
+        let recoveredSeparator = defaults.object(forKey: separatorKey)
+        #expect(recoveredMain == nil)
+        #expect(recoveredSeparator == nil)
         #expect(defaults.bool(forKey: "SaneBar_PositionRecovery_Migration_v1"))
 
         // User rearranges after recovery.


### PR DESCRIPTION
## Summary

Remove ordinal position pre-seeding that causes status bar icons to be placed at the far left of the menu bar instead of near Control Center.

## Changes

- Remove `seedPositionsIfNeeded()` calls from `init()`, `recreateItemsWithBumpedVersion()`, and `recoverStartupPositions()`
- Remove dead code: `seedPositionsIfNeeded()`, `forceMainAndSeparatorAnchorSeed()`, `shouldForceAnchorNearControlCenterOnLaunch()`, `shouldSeedPreferredPosition()`
- Update corruption recovery tests to expect cleared positions (nil) instead of seeded ordinals (0, 1)

## Related Issues

Follows up on the self-healing autosave fix adopted in v2.1.16.

## Root Cause

The pre-seeding writes `main=0, separator=1` to `NSStatusItem Preferred Position` keys before creating items, assuming macOS interprets these as ordinal hints (`0 = rightmost`). In practice, macOS treats them as literal pixel X
coordinates — placing the main icon at X ≈ 0 (far left). When `HidingService` expands the separator to ~5000px, the misplaced main icon gets pushed off-screen.

The version bump mechanism doesn't help because it re-seeds the same (0, 1) values each time — creating an infinite loop.

Before (all autosave versions):

Main icon:  X = -1,  separator width = 5002  ← icon pushed off-screen

After (macOS auto-places without seeding):

Main icon:  X = 3483, Separator: X = 3461   ← correct, near Control Center

Without pre-seeding, macOS auto-places new `NSStatusItem`s near Control Center correctly.

## A Note

Sorry that my previous PR's approach (bumping `baseAutosaveVersion` to 8) didn't fully solve the problem — it escaped the corrupted cache initially but the re-seeding brought the issue back. I'm not an expert on macOS internals; I just
  dug into the UserDefaults/ByHost state and Accessibility API output to trace the actual icon positions, then worked with Claude to get the tests passing and verify the fix on my machine. Hopefully this is closer to the real root cause
  this time.

## Testing

- [x] Ran `./scripts/SaneMaster.rb verify` (build + tests pass)
- [x] Tested manually on macOS
- [x] Added/updated tests for new functionality
- [x] Verified icon position via Accessibility API (X = 3483, right side)
- [x] Confirmed all 62 tests pass across 3 suites
- [ ] Verify on clean install (no existing UserDefaults)
- [ ] Verify existing healthy user layouts are preserved across update

## Screenshots (if UI changes)

N/A — menu bar icon returns to its expected position near Control Center.

## Checklist

- [x] Code follows project style guidelines
- [x] Self-reviewed the code
- [x] Commented complex logic
- [x] Updated documentation if needed

## Sane Philosophy Check

_"Not fear, but power, love, and sound mind" — 2 Timothy 1:7_

- [x] **Fear**: Does this REDUCE user fear, not create it?
- [x] **Power**: Does the user maintain control?
- [x] **Love**: Does this genuinely help people?
- [x] **Sound Mind**: Is the UI clear and calm?
- [x] **Grandma Test**: Would her life be better with this installed?